### PR TITLE
add:ヘッダー・フッター・top手直し

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title><%= content_for(:title) || "Myapp" %></title>
+    <title><%= content_for(:title) || "お風呂クエスト" %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <%= csrf_meta_tags %>
@@ -17,7 +17,17 @@
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
   </head>
 
-  <body class="bg-orange-600">
-    <%= yield %>
+  <!-- min-h-screenがfooter動かんようにしてくれる -->
+  <body class="min-h-screen flex flex-col">
+    <%= render "shared/header" %>
+
+    <main class="flex-1">
+      <!-- 横幅上限・左右中央寄せ・画面端ギリギリ防止（余白） -->
+      <div class="max-w-md mx-auto px-4">
+        <%= yield %>
+      </div>
+    </main>
+
+    <%= render "shared/footer" %>
   </body>
 </html>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,0 +1,5 @@
+<footer class="w-full bg-gray-100">
+  <div class="max-w-md mx-auto p-4 text-sm text-gray-500 text-center border-t border-gray-200">
+    © 2026 お風呂クエスト
+  </div>
+</footer>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,0 +1,14 @@
+<header class="sticky top-0 h-16 bg-white border-b">
+  <div class="max-w-md mx-auto px-4 py-3 flex items-center justify-between">
+
+    <!-- アプリ名：今後、ロゴに置き換え -->
+    <%= link_to "お風呂クエスト", root_path, class: "text-lg font-bold text-gray-800" %>
+
+    <!-- メニュー：今後、スマホ・タブレットをハンバーガー -->
+    <nav class="flex items-center gap-3 text-sm">
+      <%= link_to "登録", "#", class: "px-2 py-1 rounded hover:bg-gray-100" %>
+      <%= link_to "ログイン", "#", class: "px-2 py-1 rounded hover:bg-gray-100" %>
+    </nav>
+
+  </div>
+</header>

--- a/app/views/static_pages/index.html.erb
+++ b/app/views/static_pages/index.html.erb
@@ -1,2 +1,8 @@
-<h1>StaticPages#index</h1>
-<p>Find me in app/views/static_pages/index.html.erb</p>
+<!-- 100vh(画面の高さ)-64px(ヘッダーの高さ) -->
+<div class="min-h-[calc(100vh-64px)] flex flex-col items-center justify-center text-center">
+  <h1 class="text-4xl font-bold mb-6">
+    お風呂クエスト
+  </h1>
+
+  <%= link_to "みにいく", "#", class: "px-6 py-3 rounded-lg bg-blue-500 text-white hover:bg-blue-600 transition" %>
+</div>


### PR DESCRIPTION
- [x] headerの作成
  - [x] 仮ロゴ(テキストのみ)を表示
- [x] footerの作成
  - [x] コンテンツの高さが足りない場合にfooterが浮かないように
(min-h-screenで動かないように)
- [x] 全てのページでheaderとfooterが表示されるように記述
  - [x] `application.html.erb`にheaderとfooterを記載