### PR TITLE
add:投稿詳細画面追加

### DIFF
--- a/app/controllers/bath_hacks_posts_controller.rb
+++ b/app/controllers/bath_hacks_posts_controller.rb
@@ -1,5 +1,5 @@
 class BathHacksPostsController < ApplicationController
-    before_action :authenticate_user!, except: [ :index ]
+    before_action :authenticate_user!, except: [ :index, :show ]
 
   def index
     @bath_hacks_posts = BathHacksPost.includes(:user).order(created_at: :desc)
@@ -18,6 +18,10 @@ class BathHacksPostsController < ApplicationController
       flash.now[:alert] = "投稿できませんでした"
       render :new, status: :unprocessable_entity
     end
+  end
+
+  def show
+    @bath_hacks_post = BathHacksPost.find(params[:id])
   end
 
   private

--- a/app/views/bath_hacks_posts/_bath_hacks_post.html.erb
+++ b/app/views/bath_hacks_posts/_bath_hacks_post.html.erb
@@ -7,7 +7,7 @@
 
   <!-- タイトル（詳細リンク） -->
 <h2 class="text-base font-semibold truncate">
-  <%= link_to "#",
+  <%= link_to bath_hacks_post_path(bath_hacks_post),
         class: "block text-gray-800 hover:underline hover:text-gray-900" do %>
     <%= bath_hacks_post.title %>
   <% end %>

--- a/app/views/bath_hacks_posts/show.html.erb
+++ b/app/views/bath_hacks_posts/show.html.erb
@@ -1,0 +1,29 @@
+<div class="min-h-full py-8">
+  <div class="max-w-md mx-auto px-4">
+
+    <div class="bg-gray-50 border border-gray-200 rounded-lg p-6">
+
+      <!-- 投稿者名 -->
+      <div class="text-xs text-gray-500 mb-2">
+        <%= @bath_hacks_post.user.name %> さん
+      </div>
+
+      <!-- タイトル（全文） -->
+      <h1 class="text-xl font-bold text-gray-900 mb-4">
+        <%= @bath_hacks_post.title %>
+      </h1>
+
+      <!-- 本文（全文） -->
+      <div class="text-sm text-gray-800 leading-relaxed whitespace-pre-wrap mb-8">
+        <%= @bath_hacks_post.content %>
+      </div>
+
+      <!-- 更新日 -->
+      <div class="text-xs text-gray-400 text-right">
+        <%= @bath_hacks_post.updated_at.strftime("%Y/%m/%d") %> 更新
+      </div>
+
+    </div>
+
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
   root "static_pages#index"
 
-  resources :bath_hacks_posts, only: %i[index new create]
+  resources :bath_hacks_posts, only: %i[index new create show]
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check


### PR DESCRIPTION
#作業内容
## 投稿詳細画面追加
- [x] ルーティングにshowを追加
- [x] コントローラ編集
  - [x] 詳細画面をログインなしでも遷移できるようにした
  - [x] showアクション追加
- [x]  投稿詳細ビュー追加・編集
- [x] 投稿一覧のタイトルから投稿詳細画面に遷移できるようにした